### PR TITLE
Network utils improvements

### DIFF
--- a/networkentropy/network_utils.py
+++ b/networkentropy/network_utils.py
@@ -12,19 +12,19 @@ import pandas as pd
 import copy
 from bs4 import BeautifulSoup
 
-NAME = "name"
-CATEGORY = "category"
-NUM_NODES = "num_nodes"
-NUM_EDGES = "num_edges"
-TSV_URL = "tsv_url"
+NAME = 'name'
+CATEGORY = 'category'
+NUM_NODES = 'num_nodes'
+NUM_EDGES = 'num_edges'
+TSV_URL = 'tsv_url'
 
 
 class DatasetsStrategy:
     def get_networks_url(self) -> str:
-        raise NotImplementedError("Method get_networks_url must be implemented")
+        raise NotImplementedError('Method get_networks_url must be implemented')
 
     def get_networks_from_response(self, response) -> List[object]:
-        raise NotImplementedError("Method get_networks_from_response must be implemented")
+        raise NotImplementedError('Method get_networks_from_response must be implemented')
 
 
 class Datasets:
@@ -34,7 +34,7 @@ class Datasets:
 
         response = self._request_networks()
         if response.status_code != 200:
-            print("An error occurred while getting data.")
+            print('An error occurred while getting data.')
         else:
             networks = self._get_networks_from_response(response)
             self.networks = self._map_to_dataframe(networks)
@@ -98,7 +98,7 @@ class Datasets:
         elif combine_queries:
             query_expr = self._build_query(categories, min_size, max_size, min_density, max_density, query_expr)
         if not query_expr:
-            raise ValueError("Either query_expr or other filtering parameter must be specified")
+            raise ValueError('Either query_expr or other filtering parameter must be specified')
         if inplace:
             datasets = self
         else:
@@ -109,29 +109,29 @@ class Datasets:
     def _build_query(self, categories, min_size, max_size, min_density, max_density, base_query=None) -> str:
         query = []
         if base_query is not None:
-            query.append("({})".format(base_query))
+            query.append('({})'.format(base_query))
         if categories is not None:
-            query.append("{} in @categories".format(CATEGORY))
+            query.append('{} in @categories'.format(CATEGORY))
         if min_size is not None:
-            query.append("{} >= @min_size".format(NUM_NODES))
+            query.append('{} >= @min_size'.format(NUM_NODES))
         if max_size is not None:
-            query.append("{} <= @max_size".format(NUM_NODES))
+            query.append('{} <= @max_size'.format(NUM_NODES))
         if min_density is not None:
-            query.append("({m} / ({n} * ({n} - 1))) >= @min_density".format(m=NUM_EDGES, n=NUM_NODES))
+            query.append('({m} / ({n} * ({n} - 1))) >= @min_density'.format(m=NUM_EDGES, n=NUM_NODES))
         if max_density is not None:
-            query.append("({m} / ({n} * ({n} - 1))) <= @max_density".format(m=NUM_EDGES, n=NUM_NODES))
-        return " and ".join(query)
+            query.append('({m} / ({n} * ({n} - 1))) <= @max_density'.format(m=NUM_EDGES, n=NUM_NODES))
+        return ' and '.join(query)
 
 
 class KonectCCStrategy(DatasetsStrategy):
-    networks_url = "http://konect.cc/networks/"
+    networks_url = 'http://konect.cc/networks/'
 
     def get_networks_url(self) -> str:
         return self.networks_url
 
     def get_networks_from_response(self, response) -> List[object]:
         html = response.content
-        soup = BeautifulSoup(html, "lxml")
+        soup = BeautifulSoup(html, 'lxml')
 
         table_html = soup.find('table')
         rows = table_html.findAll('tr')
@@ -148,15 +148,24 @@ class KonectCCStrategy(DatasetsStrategy):
         return networks
 
 
+class KonectUniStrategy(DatasetsStrategy):
+
+    def get_networks_url(self) -> str:
+        return 'http://konect.uni-koblenz.de/networks/'
+
+    def get_networks_from_response(self, response) -> List[object]:
+        pass
+
+
 def create_datasets(name):
-    if name == "konect.cc":
+    if name == 'konect.cc':
         strategy = KonectCCStrategy()
     else:
-        raise ValueError("Strategy with {} does not exist".format(name))
+        raise ValueError('Strategy with {} does not exist'.format(name))
     return Datasets(strategy)
 
 
-def read_available_datasets_konect(name="konect.cc") -> List[object]:
+def read_available_datasets_konect(name='konect.cc') -> List[object]:
     datasets = create_datasets(name)
     return datasets.to_list()
 
@@ -194,8 +203,8 @@ def unpack_tar_bz2_file(file_name: str, dir_name: str) -> str:
     :return: name of the directory where unpacked files are
     """
 
-    tar = tarfile.open(dir_name + file_name, "r:bz2")
-    output_dir = dir_name + "network_" + file_name.replace('.tar.bz2', '') + "/"
+    tar = tarfile.open(dir_name + file_name, 'r:bz2')
+    output_dir = dir_name + 'network_' + file_name.replace('.tar.bz2', '') + '/'
 
     tar.extractall(output_dir)
     tar.close()

--- a/networkentropy/network_utils.py
+++ b/networkentropy/network_utils.py
@@ -11,7 +11,7 @@ import networkx as nx
 from urllib.request import HTTPError
 
 
-def read_avalilable_datasets_konect() -> List[object] :
+def read_available_datasets_konect() -> List[object]:
     """
     Reads the list of all networks available through the Koblenz network repository
     :return: list of network names and sizes (vertices and edges)
@@ -30,10 +30,10 @@ def read_avalilable_datasets_konect() -> List[object] :
         rows = table_html.findAll('tr')
 
         networks = [
-            (row.find_all('td')[1].a.get('href').replace('/',''),
+            (row.find_all('td')[1].a.get('href').replace('/', ''),
              row.find_all('td')[2].div.get('title'),
-             int(row.find_all('td')[3].text.replace(',','')),
-             int(row.find_all('td')[4].text.strip('\n').replace(',',''))
+             int(row.find_all('td')[3].text.replace(',', '')),
+             int(row.find_all('td')[4].text.strip('\n').replace(',', ''))
              )
             for row
             in rows[1:]
@@ -63,7 +63,7 @@ def download_tsv_dataset_konect(network_name: str,
     :return: name of the downloaded file
     """
 
-    assert (network_name in [name for (name, cat, vsize, esize) in read_avalilable_datasets_konect()]), \
+    assert (network_name in [name for (name, cat, vsize, esize) in read_available_datasets_konect()]), \
         "No network named: '" + network_name + "' found in Konect!"
 
     if min_size:

--- a/networkentropy/network_utils.py
+++ b/networkentropy/network_utils.py
@@ -8,6 +8,7 @@ import networkx as nx
 import requests
 import wget
 import pandas as pd
+import copy
 from bs4 import BeautifulSoup
 
 NAME = "name"
@@ -54,8 +55,19 @@ class Datasets:
             NUM_EDGES: transposed_networks[3]
         })
 
-    def to_list(self) -> List[object]:
+    def to_list(self) -> List[List[object]]:
+        """
+        Returns datasets information as list
+        :return: datasets information as list
+        """
         return self.networks.values.tolist()
+
+    def to_df(self) -> pd.DataFrame:
+        """
+        Returns datasets information as DataFrame
+        :return: datasets information as DataFrame
+        """
+        return self.networks
 
     def filter(self,
                inplace: bool = False,
@@ -64,12 +76,27 @@ class Datasets:
                min_size: int = None,
                max_size: int = None,
                min_density: int = None,
-               max_density: float = None) -> pd.DataFrame:
+               max_density: float = None) -> 'Datasets':
+        """
+        :param inplace: specifies whether Dataset should be modified or a modified copy should be returned
+        :param query_expr: query expression, if specified, other arguments are ignored
+        :param categories: categories to be included
+        :param min_size: minimum number of nodes required in the network
+        :param max_size: maximum number of nodes allowed in the network
+        :param min_density: minimum density of network allowed
+        :param max_density: maximum density of network allowed
+        :return: Modified Datasets object
+        """
         if query_expr is None:
             query_expr = self._build_query(categories, min_size, max_size, min_density, max_density)
         if not query_expr:
             raise ValueError("Either query_expr or other filtering parameter must be specified")
-        return self.networks.query(query_expr, inplace=inplace)
+        if inplace:
+            datasets = self
+        else:
+            datasets = copy.deepcopy(self)
+        datasets.networks.query(query_expr, inplace=True)
+        return datasets
 
     def _build_query(self, categories, min_size, max_size, min_density, max_density) -> str:
         query = []

--- a/networkentropy/network_utils.py
+++ b/networkentropy/network_utils.py
@@ -126,9 +126,18 @@ class Datasets:
         if max_density is not None:
             query.append('({m} / ({n} * ({n} - 1))) <= @max_density'.format(m=NUM_EDGES, n=NUM_NODES))
         if only_downloadable:
-            # using the fact that NaN != NaN, somehow iot works for None values in queries as well
+            # using the fact that NaN != NaN, somehow it works for None values in queries as well
             query.append('{url} == {url}'.format(url=TSV_URL))
         return ' and '.join(query)
+
+    def download_and_build_networks(self, dir_name):
+        """
+        Downloads networks data and creates NetworkX graph objects from the data
+        :param dir_name: name of the directory to download files to
+        :return: Series of NetworkX graph objects (Series may contain None for graphs that couldn't be downloaded
+        """
+        return self.networks.loc[:, [NAME, TSV_URL]].apply(
+            lambda r: build_network_from_out_konect(r[0], r[1], dir_name), axis=1)
 
 
 class KonectCCStrategy(DatasetsStrategy):


### PR DESCRIPTION
Improvements for easier use and filtering have been implemented. 
Support for http://konect.uni-koblenz.de/networks/ has also been added. (http://konect.cc/networks/ is also supported)

Example usage:

```
# Creating datasets object using http://konect.cc/
datasetsCC = nu.create_datasets("konect.cc")

# Creating datasets object using http://konect.uni-koblenz.de
datasetsUni = nu.create_datasets("konect.uni")

# Filtering
filteredDatasets = datasetsCC.filter(categories=["Affiliation network", "Human contact network"], min_size=150)

# Getting DataFrame
df = filteredDatasets.to_df()

#Getting list
datasets_list = filteredDatasets.to_list()

#Getting NetworkX graph objects
networks = datasets_list = filteredDatasets.download_and_build_networks('data/')
```
